### PR TITLE
Center icons for select category

### DIFF
--- a/shared/src/commonMain/kotlin/ui/AddExpensesScreen.kt
+++ b/shared/src/commonMain/kotlin/ui/AddExpensesScreen.kt
@@ -13,13 +13,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.BottomSheetScaffold
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
@@ -33,7 +31,6 @@ import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -218,7 +215,8 @@ fun CategoryItem(category: ExpenseCategory, onCategorySelected: (ExpenseCategory
             .fillMaxWidth()
             .padding(8.dp)
             .clickable { onCategorySelected(category) },
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Image(
             imageVector = category.icon,


### PR DESCRIPTION
# Center icons
🇺🇸[EN]
Hi  Gastón.
Excellent project to practice with KMP. I would like to participate in this project. 

The reason for Pull Request: 
The Icons when we added a new expense was not centered container to the title of each category. 

🇪🇸[ESP]
Buenas Gastón.
Excelente proyecto para ir practicando con KMP.  me gustaría participar en este proyecto. 

El porque del Pull Request: 
Los Iconos cuando agregamos un nuevo gasto no estaba centrado envase al titulo de cada categoría 

APP Running / APP Corriendo:

## 🍎iOS
| Before / Antes | After / Después |
|:--------------:|:---------------:|
| <img src="https://github.com/gastsail/expenses-KMP/assets/57275367/5cd4237c-090e-4921-ac53-e61f0b1d5531" height="400"> | <img src="https://github.com/gastsail/expenses-KMP/assets/57275367/468f0ce0-2e73-4ac1-b6b9-9ddb1dc96c23" height="400"> |

## 🤖Android 
| Before / Antes | After / Después |
|:--------------:|:---------------:|
| <img src="https://github.com/gastsail/expenses-KMP/assets/57275367/83c8bb0d-65de-4feb-b76b-c417176eff8b)" height="400"> | <img src="https://github.com/gastsail/expenses-KMP/assets/57275367/468f0ce0-2e73-4ac1-b6b9-9ddb1dc96c23" height="400"> |


# Query
I would like to contribute to the project if possible I could make the screen to edit an expense.
If I can I would like to consult:
- To go to the edit screen we add a button to edit it with a pencil or another icon ? or when you click on any expense ?

# Consulta
Quisiera ir aportando al proyecto si es posible podría hacer la pantalla de editar un gasto ?.
Si puedo quisiera consultar:
- Para ir a la pantalla de editar agregamos un botón para editarlo con un lápiz o otro  icono ? o cuando da click a algún gasto?
